### PR TITLE
Pass VERSION from GitHub action configuration to docker push action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,3 +29,4 @@ jobs:
         name: "${{ env.IMAGE }}:${{ env.VERSION }}"
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+        buildargs: VERSION


### PR DESCRIPTION
Configure GitHub action to pass version (which is determined based on whether we build the master branch or a tag) to the referenced docker push GitHub action