### PR TITLE
Update icinga2 client import

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,10 @@ jobs:
         go: [ '1.14', '1.13', '1.12' ]
     name: Go get with Go ${{ matrix.go }}
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v2-beta
       with:
         go-version: ${{ matrix.go }}
-    - name: Go get Signalilo
-      run: go get github.com/vshn/signalilo
+    - run: go get -v github.com/vshn/signalilo@${{ github.head_ref }}
+      env:
+        GO111MODULE: on
+    - run: signalilo --version

--- a/config/config.go
+++ b/config/config.go
@@ -15,11 +15,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/Nexinto/go-icinga2-client/icinga2"
 	"github.com/bketelsen/logr"
 	"github.com/corvus-ch/logr/buffered"
 	log "github.com/corvus-ch/logr/logrus"
 	"github.com/sirupsen/logrus"
+	"github.com/vshn/go-icinga2-client/icinga2"
 )
 
 type icingaConfig struct {

--- a/gc/gc.go
+++ b/gc/gc.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/vshn/signalilo/config"
-	"github.com/Nexinto/go-icinga2-client/icinga2"
+	"github.com/vshn/go-icinga2-client/icinga2"
 )
 
 // extractDowntime searches the provided downtime array for a downtime for

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,13 @@
 module github.com/vshn/signalilo
 
 require (
-	github.com/Nexinto/go-icinga2-client v0.0.0-20180829072643-d4f6001a2110
 	github.com/bketelsen/logr v0.0.0-20170116012416-f3d070bdd1c5
 	github.com/corvus-ch/logr v0.0.0-20180917163152-45217966b77e
 	github.com/prometheus/alertmanager v0.20.0
 	github.com/sirupsen/logrus v1.5.0
 	github.com/stretchr/testify v1.5.1
+	github.com/vshn/go-icinga2-client v0.0.6
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
-
-replace github.com/Nexinto/go-icinga2-client => github.com/vshn/go-icinga2-client v0.0.5
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/vshn/go-icinga2-client v0.0.5 h1:F3TL/QuJQNT2kgVxucSenyCv19gFkH27CILY6XUVBVs=
-github.com/vshn/go-icinga2-client v0.0.5/go.mod h1:an7WxQ9/P5l4423TAkmVsMDV4t54m1q6RZDmE/Hmpok=
+github.com/vshn/go-icinga2-client v0.0.6 h1:0DNvemSk4uAVAFTnmbWifvHvGWWmV8rM3cBxb1sXCGk=
+github.com/vshn/go-icinga2-client v0.0.6/go.mod h1:T6r6HQ22NZsSUI/u5ThOlPsQrtbnJIImZTPAvEOSCdI=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/serve.go
+++ b/serve.go
@@ -14,11 +14,11 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/bketelsen/logr"
+	"github.com/vshn/go-icinga2-client/icinga2"
 	"github.com/vshn/signalilo/config"
 	"github.com/vshn/signalilo/gc"
 	"github.com/vshn/signalilo/webhook"
-	"github.com/Nexinto/go-icinga2-client/icinga2"
-	"github.com/bketelsen/logr"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/serve_test.go
+++ b/serve_test.go
@@ -10,8 +10,8 @@
 package main
 
 import (
-	"github.com/vshn/signalilo/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/vshn/signalilo/config"
 	"net/http"
 	"testing"
 )

--- a/webhook/hook.go
+++ b/webhook/hook.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"github.com/vshn/signalilo/config"
-	"github.com/Nexinto/go-icinga2-client/icinga2"
+	"github.com/vshn/go-icinga2-client/icinga2"
 	"github.com/prometheus/alertmanager/template"
 )
 

--- a/webhook/icinga.go
+++ b/webhook/icinga.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/vshn/signalilo/config"
-	"github.com/Nexinto/go-icinga2-client/icinga2"
+	"github.com/vshn/go-icinga2-client/icinga2"
 	"github.com/prometheus/alertmanager/template"
 )
 

--- a/webhook/icinga_test.go
+++ b/webhook/icinga_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/vshn/signalilo/config"
-	"github.com/Nexinto/go-icinga2-client/icinga2"
+	"github.com/vshn/go-icinga2-client/icinga2"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/stretchr/testify/assert"
 )

--- a/webhook/variable_mapping.go
+++ b/webhook/variable_mapping.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/Nexinto/go-icinga2-client/icinga2"
+	"github.com/vshn/go-icinga2-client/icinga2"
 	"github.com/bketelsen/logr"
 )
 

--- a/webhook/variable_mapping_test.go
+++ b/webhook/variable_mapping_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Nexinto/go-icinga2-client/icinga2"
+	"github.com/vshn/go-icinga2-client/icinga2"
 	"github.com/corvus-ch/logr/buffered"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
* Switch `go-icinga2-client` import to use `vshn/go-icinga2-client` directly, because `replace` is not supported by `go get` to import a fork of a module, see golang/go#30354
* Change the `go get` test to actually test the changes in the PR