### PR TITLE
Add ability to disable http keep-alives when connecting to Icinga2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Optional
 * `--icinga_insecure_tls`/`SIGNALILO_ICINGA_INSECURE_TLS`:
   If true, disable strict TLS checking of Icinga2 API SSL certificate
   (default: false).
+* `--icinga_disable_keepalives`/`SIGNALILO_ICINGA_DISABLE_KEEPALIVES`:
+  If true, disable http keep-alives with Icinga2 API and will only use
+  the connection to the server for a single HTTP request 
+  (default: false).
 * `--icinga_debug`/`SIGNALILO_ICINGA_DEBUG`:
   If true, enable debugging mode in Icinga client (default: false).
 * `--icinga_gc_interval`/`SIGNALILO_ICINGA_GC_INTERVAL`:

--- a/config/config.go
+++ b/config/config.go
@@ -23,11 +23,12 @@ import (
 )
 
 type icingaConfig struct {
-	URL         string
-	User        string
-	Password    string
-	InsecureTLS bool
-	Debug       bool
+	URL               string
+	User              string
+	Password          string
+	InsecureTLS       bool
+	DisableKeepAlives bool
+	Debug             bool
 }
 
 type Configuration interface {
@@ -99,12 +100,13 @@ func newIcingaClient(c *SignaliloConfig, l logr.Logger) (icinga2.Client, error) 
 	}
 
 	client, err := icinga2.New(icinga2.WebClient{
-		URL:         c.IcingaConfig.URL,
-		Username:    c.IcingaConfig.User,
-		Password:    c.IcingaConfig.Password,
-		Debug:       c.IcingaConfig.Debug,
-		InsecureTLS: c.IcingaConfig.InsecureTLS,
-		RootCAs:     rootCAs})
+		URL:               c.IcingaConfig.URL,
+		Username:          c.IcingaConfig.User,
+		Password:          c.IcingaConfig.Password,
+		Debug:             c.IcingaConfig.Debug,
+		InsecureTLS:       c.IcingaConfig.InsecureTLS,
+		DisableKeepAlives: c.IcingaConfig.DisableKeepAlives,
+		RootCAs:           rootCAs})
 	if err != nil {
 		return nil, err
 	}
@@ -158,11 +160,12 @@ func NewMockConfiguration(verbosity int) Configuration {
 		UUID:     "",
 		HostName: "signalilo_appuio_lab",
 		IcingaConfig: icingaConfig{
-			URL:         "localhost:5665",
-			User:        "sepp",
-			Password:    "sepp1",
-			InsecureTLS: true,
-			Debug:       false,
+			URL:               "localhost:5665",
+			User:              "sepp",
+			Password:          "sepp1",
+			InsecureTLS:       true,
+                        DisableKeepAlives: false,
+			Debug:             false,
 		},
 		GcInterval: 1 * time.Minute,
 		AlertManagerConfig: alertManagerConfig{

--- a/config/config.go
+++ b/config/config.go
@@ -164,7 +164,7 @@ func NewMockConfiguration(verbosity int) Configuration {
 			User:              "sepp",
 			Password:          "sepp1",
 			InsecureTLS:       true,
-                        DisableKeepAlives: false,
+			DisableKeepAlives: false,
 			Debug:             false,
 		},
 		GcInterval: 1 * time.Minute,

--- a/serve.go
+++ b/serve.go
@@ -169,6 +169,7 @@ func configureServeCommand(app *kingpin.Application) {
 	serve.Flag("icinga_username", "Icinga Username").Envar("SIGNALILO_ICINGA_USERNAME").Required().StringVar(&s.config.IcingaConfig.User)
 	serve.Flag("icinga_password", "Icinga Password").Envar("SIGNALILO_ICINGA_PASSWORD").Required().StringVar(&s.config.IcingaConfig.Password)
 	serve.Flag("icinga_insecure_tls", "Skip Icinga TLS verification").Envar("SIGNALILO_ICINGA_INSECURE_TLS").Default("false").BoolVar(&s.config.IcingaConfig.InsecureTLS)
+	serve.Flag("icinga_disable_keepalives", "Disable HTTP keepalives").Envar("SIGNALILO_ICINGA_DISABLE_KEEPALIVES").Default("false").BoolVar(&s.config.IcingaConfig.DisableKeepAlives)
 	serve.Flag("icinga_debug", "Enable debug-level logging for icinga2 client library").Envar("SIGNALILO_ICINGA_DEBUG").Default("false").BoolVar(&s.config.IcingaConfig.Debug)
 	serve.Flag("icinga_heartbeat_interval", "Heartbeat interval to Icinga").Envar("SIGNALILO_ICINGA_HEARTBEAT_INTERVAL").Default("1m").DurationVar(&s.config.HeartbeatInterval)
 	serve.Flag("icinga_gc_interval", "Garbage collection interval for old alerts").Envar("SIGNALILO_ICINGA_GC_INTERVAL").Default("15m").DurationVar(&s.config.GcInterval)


### PR DESCRIPTION
Hello,

this PR is the second of two related to:

         https://github.com/vshn/signalilo/issues/29

and is exposing the possibility to tune http keepalive.