### PR TITLE
Allow changing the annotation name used for plugin_output

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Optional
   Path of private key file for TLS-enabled webhook endpoint. TLS is enabled
   when both TLS_CERT and TLS_KEY are set.
 * `--alertmanager_pluginoutput_annotations`:
-  The name of an annotation to retrive the `plugin_output` from. Can be set multiple times in which case the first annotation with a value found is used.
+  The name of an annotation to retrieve the `plugin_output` from. Can be set multiple times in which case the first annotation with a value found is used.
 
 ## Integration to Prometheus/Alertmanager.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Optional
 * `--alertmanager_tls_key`/`SIGNALILO_ALERTMANAGER_TLS_KEY`:
   Path of private key file for TLS-enabled webhook endpoint. TLS is enabled
   when both TLS_CERT and TLS_KEY are set.
+* `--alertmanager_pluginoutput_annotations`:
+  The name of an annotation to retrive the `plugin_output` from. Can be set multiple times in which case the first annotation with a value found is used.
 
 ## Integration to Prometheus/Alertmanager.
 
@@ -126,6 +128,8 @@ Required annotations:
 * `summary` mapped to `display_name`.
 * `description`: mapped to `notes`.
 * `message`: mapped to `plugin_output`.
+
+You can also use the `--alertmanager_pluginoutput_annotations` option to change the annotation used for the `plugin_output`.
 
 ## Integration with Icinga
 

--- a/config/config.go
+++ b/config/config.go
@@ -44,10 +44,11 @@ type Configuration interface {
 }
 
 type alertManagerConfig struct {
-	BearerToken string
-	TLSCertPath string
-	TLSKeyPath  string
-	UseTLS      bool
+	BearerToken             string
+	TLSCertPath             string
+	TLSKeyPath              string
+	UseTLS                  bool
+	PluginOutputAnnotations []string
 }
 
 type SignaliloConfig struct {

--- a/serve.go
+++ b/serve.go
@@ -191,4 +191,7 @@ func configureServeCommand(app *kingpin.Application) {
 	serve.Flag("alertmanager_bearer_token", "Bearer token for incoming requests").Envar("SIGNALILO_ALERTMANAGER_BEARER_TOKEN").Required().StringVar(&s.config.AlertManagerConfig.BearerToken)
 	serve.Flag("alertmanager_tls_cert", "Path of certificate file for TLS-enabled webhook endpoint. Should contain the full chain").Envar("SIGNALILO_ALERTMANAGER_TLS_CERT").StringVar(&s.config.AlertManagerConfig.TLSCertPath)
 	serve.Flag("alertmanager_tls_key", "Path of private key file for TLS-enabled webhook endpoint").Envar("SIGNALILO_ALERTMANAGER_TLS_KEY").StringVar(&s.config.AlertManagerConfig.TLSKeyPath)
+
+	serve.Flag("alertmanager_pluginoutput_annotations", "List of Annotation names to be used to set the Plugin Output for the Icinga Service").Default("message").Envar("SIGNALILO_ALERTMANAGER_PLUGINOUTPUT_ANNOTATIONS").StringsVar(&s.config.AlertManagerConfig.PluginOutputAnnotations)
+
 }

--- a/webhook/hook.go
+++ b/webhook/hook.go
@@ -142,9 +142,19 @@ func Webhook(w http.ResponseWriter, r *http.Request, c config.Configuration) {
 		}
 		l.V(2).Infof("Executing ProcessCheckResult on icinga2 for %v: exit status %v",
 			serviceName, exitStatus)
+
+		// Get the Plugin Output from the first Annotation we find that has some data
+		pluginOutput := ""
+		for _, v := range c.GetConfig().AlertManagerConfig.PluginOutputAnnotations {
+			pluginOutput = alert.Annotations[v]
+			if pluginOutput != "" {
+				break
+			}
+		}
+
 		err = icinga.ProcessCheckResult(svc, icinga2.Action{
 			ExitStatus:   exitStatus,
-			PluginOutput: alert.Annotations["message"],
+			PluginOutput: pluginOutput,
 		})
 		if err != nil {
 			l.Errorf("Error in ProcessCheckResult for %v: %v", serviceName, err)


### PR DESCRIPTION
We use the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) which comes with a large set of Rules not all of which have a `message` annotation.

This results in some Services being created with a blank `plugin_output` but with additional vars such as `description` that have text that could be used as the `plugin_output` value.

This PR adds an option `--alertmanager_pluginoutput_annotations` to specify an alternative annotation name, or list of annotation names if the option is repeated, that will be searched with the first one with content being used for the `plugin_output`.
