### PR TITLE
Update alertmanager mapping section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,21 @@ information, the check generated in Icinga will be lacking.
 Required labels:
 
 * `severity`: Must be one of `WARNING` or `CRITICAL`.
+* `alertname` mapped to `display_name`.
 
 Required annotations:
 
-* `summary` mapped to `display_name`.
 * `description`: mapped to `notes`.
 * `message`: mapped to `plugin_output`.
+
+Optional annotations:
+
+* `runbook_url`: mapped to `notes_url
+
+Infered fields:
+
+* `generatorURL`: mapped to `action_url`
+
 
 ## Integration with Icinga
 


### PR DESCRIPTION
According to https://github.com/vshn/signalilo/blob/f0309f3cb60749abbd508a639a767c0f6914dd52/webhook/icinga.go#L82
the display_name field is taken from alertname label.
Additionnal mappings have been added to readme too