### PR TITLE
Added --alertmanager_custom_severity_levels option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Optional
   when both TLS_CERT and TLS_KEY are set.
 * `--alertmanager_pluginoutput_annotations`:
   The name of an annotation to retrieve the `plugin_output` from. Can be set multiple times in which case the first annotation with a value found is used.
+* `--alertmanager_custom_severity_levels`/`SIGNALILO_ALERTMANAGER_CUSTOM_SEVERITY_LEVELS`:
+  Add or override the default mapping of the `severity` label of the Alert to an Icinga Service State. Use the format `label_name=service_state`. The `service_state` can be `0` for OK, `1` for Warning, `2` for Critical, and `3` for Unknown. Can be set multiple times and you can also override the default values for the labels `warning` and `critical`. 
 
 ## Integration to Prometheus/Alertmanager.
 
@@ -122,7 +124,7 @@ information, the check generated in Icinga will be lacking.
 
 Required labels:
 
-* `severity`: Must be one of `WARNING` or `CRITICAL`.
+* `severity`: Must be one of `WARNING` or `CRITICAL`, or any values set via the `--alertmanager_custom_severity_levels` option.
 * `alertname` mapped to `display_name`.
 
 Required annotations:

--- a/config/config.go
+++ b/config/config.go
@@ -52,16 +52,17 @@ type alertManagerConfig struct {
 }
 
 type SignaliloConfig struct {
-	UUID               string
-	HostName           string
-	IcingaConfig       icingaConfig
-	GcInterval         time.Duration
-	AlertManagerConfig alertManagerConfig
-	HeartbeatInterval  time.Duration
-	LogLevel           int
-	KeepFor            time.Duration
-	CAData             string
-	StaticServiceVars  map[string]string
+	UUID                 string
+	HostName             string
+	IcingaConfig         icingaConfig
+	GcInterval           time.Duration
+	AlertManagerConfig   alertManagerConfig
+	HeartbeatInterval    time.Duration
+	LogLevel             int
+	KeepFor              time.Duration
+	CAData               string
+	StaticServiceVars    map[string]string
+	CustomSeverityLevels map[string]string
 }
 
 func ConfigInitialize(configuration Configuration) {

--- a/config/config.go
+++ b/config/config.go
@@ -195,22 +195,22 @@ type MockConfiguration struct {
 	icingaClient icinga2.Client
 }
 
-func (c MockConfiguration) GetConfig() *SignaliloConfig {
+func (c *MockConfiguration) GetConfig() *SignaliloConfig {
 	return &c.config
 }
-func (c MockConfiguration) GetLogger() logr.Logger {
+func (c *MockConfiguration) GetLogger() logr.Logger {
 	return c.logger
 }
-func (c MockConfiguration) GetIcingaClient() icinga2.Client {
+func (c *MockConfiguration) GetIcingaClient() icinga2.Client {
 	return c.icingaClient
 }
-func (c MockConfiguration) SetConfig(config SignaliloConfig) {
+func (c *MockConfiguration) SetConfig(config SignaliloConfig) {
 	c.config = config
 }
-func (c MockConfiguration) SetLogger(logger logr.Logger) {
+func (c *MockConfiguration) SetLogger(logger logr.Logger) {
 	c.logger = logger
 }
-func (c MockConfiguration) SetIcingaClient(icinga icinga2.Client) {
+func (c *MockConfiguration) SetIcingaClient(icinga icinga2.Client) {
 	c.icingaClient = icinga
 }
 
@@ -237,7 +237,7 @@ func NewMockConfiguration(verbosity int) Configuration {
 		KeepFor:           5 * time.Minute,
 		CAData:            "",
 	}
-	mockCfg := MockConfiguration{
+	mockCfg := &MockConfiguration{
 		config: signaliloCfg,
 	}
 	mockCfg.logger = MockLogger(mockCfg.config.LogLevel)

--- a/config/config.go
+++ b/config/config.go
@@ -240,8 +240,12 @@ func NewMockConfiguration(verbosity int) Configuration {
 	mockCfg := &MockConfiguration{
 		config: signaliloCfg,
 	}
-	mockCfg.logger = MockLogger(mockCfg.config.LogLevel)
+	log := MockLogger(mockCfg.config.LogLevel)
+	mockCfg.logger = log
 	ConfigInitialize(mockCfg)
+	// reset logger to the MockLogger, since ConfigInitialize overwrites
+	// the logger.
+	mockCfg.logger = log
 	// TODO: set mockCfg.icingaClient as mocked IcingaClient
 	return mockCfg
 }

--- a/serve.go
+++ b/serve.go
@@ -161,7 +161,8 @@ func (s *ServeCommand) initialize(ctx *kingpin.ParseContext) error {
 func configureServeCommand(app *kingpin.Application) {
 	s := &ServeCommand{logLevel: 1,
 		config: config.SignaliloConfig{
-			StaticServiceVars: map[string]string{},
+			StaticServiceVars:    map[string]string{},
+			CustomSeverityLevels: map[string]string{},
 		},
 	}
 	serve := app.Command("serve", "Run the Signalilo service").Default().Action(s.run).PreAction(s.initialize)
@@ -193,5 +194,6 @@ func configureServeCommand(app *kingpin.Application) {
 	serve.Flag("alertmanager_tls_key", "Path of private key file for TLS-enabled webhook endpoint").Envar("SIGNALILO_ALERTMANAGER_TLS_KEY").StringVar(&s.config.AlertManagerConfig.TLSKeyPath)
 
 	serve.Flag("alertmanager_pluginoutput_annotations", "List of Annotation names to be used to set the Plugin Output for the Icinga Service").Default("message").Envar("SIGNALILO_ALERTMANAGER_PLUGINOUTPUT_ANNOTATIONS").StringsVar(&s.config.AlertManagerConfig.PluginOutputAnnotations)
+	serve.Flag("alertmanager_custom_severity_levels", "Add or override the default mapping of Severity Levels to Service States. The expected format is Severity_Level=Service_State where the Service_State is 0=OK, 2=Warning, 3=Critical, 4=Unknown. Can be repeated.").Envar("SIGNALILO_ALERTMANAGER_CUSTOM_SEVERITY_LEVELS").StringMapVar(&s.config.CustomSeverityLevels)
 
 }

--- a/webhook/hook.go
+++ b/webhook/hook.go
@@ -135,7 +135,7 @@ func Webhook(w http.ResponseWriter, r *http.Request, c config.Configuration) {
 			continue
 		}
 
-		exitStatus := severityToExitStatus(alert.Status, alert.Labels["severity"])
+		exitStatus := severityToExitStatus(alert.Status, alert.Labels["severity"], c.GetConfig().CustomSeverityLevels)
 		if svc.EnableActiveChecks {
 			// override exitStatus for sending heartbeat
 			exitStatus = 0

--- a/webhook/hook.go
+++ b/webhook/hook.go
@@ -135,7 +135,7 @@ func Webhook(w http.ResponseWriter, r *http.Request, c config.Configuration) {
 			continue
 		}
 
-		exitStatus := severityToExitStatus(alert.Status, alert.Labels["severity"], c.GetConfig().CustomSeverityLevels)
+		exitStatus := severityToExitStatus(alert.Status, alert.Labels["severity"], c.GetConfig().MergedSeverityLevels)
 		if svc.EnableActiveChecks {
 			// override exitStatus for sending heartbeat
 			exitStatus = 0


### PR DESCRIPTION
Adds the option `--alertmanager_custom_severity_levels` (and matching environment variable) to allow for additional Severity Levels from the `severity` label in the Alert to be mapped to an Icinga Service State rather than having these simply set to `UNKNOWN`.

Keeps the previous defaults of `normal`, `warning`, and `critical` to maintain backwards compatibility however they can be overridden as well.

Fixes #48