### PR TITLE
docs: add missing env var and docs on how env vars work

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ Optional
 * `--alertmanager_tls_key`/`SIGNALILO_ALERTMANAGER_TLS_KEY`:
   Path of private key file for TLS-enabled webhook endpoint. TLS is enabled
   when both TLS_CERT and TLS_KEY are set.
-* `--alertmanager_pluginoutput_annotations`:
+* `--alertmanager_pluginoutput_annotations`/`SIGNALILO_ALERTMANAGER_PLUGINOUTPUT_ANNOTATIONS`:
   The name of an annotation to retrieve the `plugin_output` from. Can be set multiple times in which case the first annotation with a value found is used.
 * `--alertmanager_custom_severity_levels`/`SIGNALILO_ALERTMANAGER_CUSTOM_SEVERITY_LEVELS`:
   Add or override the default mapping of the `severity` label of the Alert to an Icinga Service State. Use the format `label_name=service_state`. The `service_state` can be `0` for OK, `1` for Warning, `2` for Critical, and `3` for Unknown. Can be set multiple times and you can also override the default values for the labels `warning` and `critical`. 
+
+The environment variable names are generated from the command-line flags. The flag is uppercased and all `-` characters are replaced with `_`. Signalilo uses the newline character `\n` to split flags that are allowed multiple times (like `SIGNALILO_ALERTMANAGER_PLUGINOUTPUT_ANNOTATIONS`) into an array.
 
 ## Integration to Prometheus/Alertmanager.
 


### PR DESCRIPTION
Adds the missing `SIGNALILO_ALERTMANAGER_PLUGINOUTPUT_ANNOTATIONS` to the readme and also adding a short explainer about flags vs. env variables and arrays as per https://github.com/vshn/signalilo/pull/44#issuecomment-745249749