### PR TITLE
Fix description for the custom severity levels command line flag

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -197,6 +197,6 @@ func configureServeCommand(app *kingpin.Application) {
 	serve.Flag("alertmanager_tls_key", "Path of private key file for TLS-enabled webhook endpoint").Envar("SIGNALILO_ALERTMANAGER_TLS_KEY").StringVar(&s.config.AlertManagerConfig.TLSKeyPath)
 
 	serve.Flag("alertmanager_pluginoutput_annotations", "List of Annotation names to be used to set the Plugin Output for the Icinga Service").Default("message").Envar("SIGNALILO_ALERTMANAGER_PLUGINOUTPUT_ANNOTATIONS").StringsVar(&s.config.AlertManagerConfig.PluginOutputAnnotations)
-	serve.Flag("alertmanager_custom_severity_levels", "Add or override the default mapping of Severity Levels to Service States. The expected format is Severity_Level=Service_State where the Service_State is 0=OK, 2=Warning, 3=Critical, 4=Unknown. Can be repeated.").Envar("SIGNALILO_ALERTMANAGER_CUSTOM_SEVERITY_LEVELS").StringMapVar(&s.config.CustomSeverityLevels)
+	serve.Flag("alertmanager_custom_severity_levels", "Add or override the default mapping of Severity Levels to Service States. The expected format is Severity_Level=Service_State where the Service_State is 0=OK, 1=Warning, 2=Critical, 3=Unknown. Can be repeated.").Envar("SIGNALILO_ALERTMANAGER_CUSTOM_SEVERITY_LEVELS").StringMapVar(&s.config.CustomSeverityLevels)
 
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->
Hi

I stumbled upon some differences between what is written in the README.md and what is described in the serve.go for the flag

I think the service_states described in the README.md are correct for Icinga2. 

```
0=OK
1=WARN
2=CRIT
3=UNK
```

Regards -- Toni

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the README.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
