### PR TITLE
Don't run `go get` tests for PRs from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ jobs:
     - name: Run image
       run: docker run --rm docker.io/vshn/signalilo:test --version
   test_go_get:
+    # Only run `go get` tests on PRs with source branch in
+    # github.com/vshn/signalilo, as go get will fail for PRs whose source
+    # branch is in a fork.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Only run `go get` tests on PRs with source branch in github.com/vshn/signalilo, as go get will fail for PRs whose source branch is in a fork.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
