### PR TITLE
Implement support for multiple Icinga2 Master API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Mandatory
 * `--icinga_hostname`/`SIGNALILO_ICINGA_HOSTNAME`:
   Name of the Servicehost in Icinga2.
 * `--icinga_url`/`SIGNALILO_ICINGA_URL`:
-  URL of the Icinga API. It's possible to specify one or more URLs. Via CLI, the parameter can be repeated. If the
-  Parameter is used as ENV, the URLs will be splittet via comma e.G.: `"http://example.com:5665,http://example2.com:5665"`.
-  Please keep in mind, the first URL will be the Icinga-Config-Master
+  URL of the Icinga API. It's possible to specify one or more URLs. Via CLI, the parameter can be repeated. 
+  If the Parameter is used as ENV, the content will be split on commas, e.g. `"http://example.com:5665,http://example2.com:5665"` will configure two masters at `http://example.com:5665` and `http://example2.com:5665`.
+  Please keep in mind that the first URL will be the Icinga-Config-Master.
 * `--icinga_username`/`SIGNALILO_ICINGA_USERNAME`:
   Authentication against Icinga2 API.
 * `--icinga_password`/`SIGNALILO_ICINGA_PASSWORD`:

--- a/README.md
+++ b/README.md
@@ -48,10 +48,9 @@ Mandatory
 * `--icinga_hostname`/`SIGNALILO_ICINGA_HOSTNAME`:
   Name of the Servicehost in Icinga2.
 * `--icinga_url`/`SIGNALILO_ICINGA_URL`:
-  URL of the Icinga API. It's possible to specify one or more URLs. Via CLI, the parameter can be repeated. If the Parameter
-  is used as ENV, the URLs will be splittet via comma e.G.: `"http://example.com:5665,http://example2.com:5665"`
-  **Please keep in mind, if the URL is switched to another Icinga-URL instead of the Icinga-Config-Master, 
- it can result in cluttered Icinga-Objects. Moreover, the FIRST URL will be the Icinga-Config-Master**
+  URL of the Icinga API. It's possible to specify one or more URLs. Via CLI, the parameter can be repeated. If the
+  Parameter is used as ENV, the URLs will be splittet via comma e.G.: `"http://example.com:5665,http://example2.com:5665"`.
+  Please keep in mind, the first URL will be the Icinga-Config-Master
 * `--icinga_username`/`SIGNALILO_ICINGA_USERNAME`:
   Authentication against Icinga2 API.
 * `--icinga_password`/`SIGNALILO_ICINGA_PASSWORD`:
@@ -81,7 +80,8 @@ Optional
 * `--icinga_ca`/`SIGNALILO_ICINGA_CA`:
   A PEM string of the trusted CA certificate for the Icinga2 API certificate.
 * `--icinga_service_checks_active`/`SIGNALILO_ICINGA_SERVICE_CHECKS_ACTIVE`:
-  Use active checks for created icinga services to leverage on Alertmanager resend interval to manage stale checks (default: false).
+  Use active checks for created icinga services to leverage on Alertmanager resend interval to manage stale checks (
+  default: false).
 * `--icinga_service_checks_command`/`SIGNALILO_ICINGA_SERVICE_CHECKS_COMMAND`:
   Name of the check command used in Icinga2 service creation (default: 'dummy').
 * `--icinga_service_checks_interval`/`SIGNALILO_ICINGA_SERVICE_CHECKS_INTERVAL`:
@@ -101,14 +101,21 @@ Optional
   Path of private key file for TLS-enabled webhook endpoint. TLS is enabled
   when both TLS_CERT and TLS_KEY are set.
 * `--alertmanager_pluginoutput_annotations`/`SIGNALILO_ALERTMANAGER_PLUGINOUTPUT_ANNOTATIONS`:
-  The name of an annotation to retrieve the `plugin_output` from. Can be set multiple times in which case the first annotation with a value found is used.
+  The name of an annotation to retrieve the `plugin_output` from. Can be set multiple times in which case the first
+  annotation with a value found is used.
 * `--alertmanager_pluginoutput_by_states`/`SIGNALILO_ALERTMANAGER_PLUGINOUTPUT_BY_STATES`:
-  Enables support for dynamically selecting the Annotation name used for the Plugin Output based on the computed Service State.
+  Enables support for dynamically selecting the Annotation name used for the Plugin Output based on the computed Service
+  State.
   See [Plugin Output](#plugin-output) for more details on this option.
 * `--alertmanager_custom_severity_levels`/`SIGNALILO_ALERTMANAGER_CUSTOM_SEVERITY_LEVELS`:
-  Add or override the default mapping of the `severity` label of the Alert to an Icinga Service State. Use the format `label_name=service_state`. The `service_state` can be `0` for OK, `1` for Warning, `2` for Critical, and `3` for Unknown. Can be set multiple times and you can also override the default values for the labels `warning` and `critical`. The `severity` label is not case sensitive.
+  Add or override the default mapping of the `severity` label of the Alert to an Icinga Service State. Use the
+  format `label_name=service_state`. The `service_state` can be `0` for OK, `1` for Warning, `2` for Critical, and `3`
+  for Unknown. Can be set multiple times and you can also override the default values for the labels `warning`
+  and `critical`. The `severity` label is not case-sensitive.
 
-The environment variable names are generated from the command-line flags. The flag is uppercased and all `-` characters are replaced with `_`. Signalilo uses the newline character `\n` to split flags that are allowed multiple times (like `SIGNALILO_ALERTMANAGER_PLUGINOUTPUT_ANNOTATIONS`) into an array.
+The environment variable names are generated from the command-line flags. The flag is uppercased and all `-` characters
+are replaced with `_`. Signalilo uses the newline character `\n` to split flags that are allowed multiple times (
+like `SIGNALILO_ALERTMANAGER_PLUGINOUTPUT_ANNOTATIONS`) into an array.
 
 ## Integration to Prometheus/Alertmanager.
 
@@ -142,7 +149,8 @@ information, the check generated in Icinga will be lacking.
 
 Required labels:
 
-* `severity`: Must be one of `warning` or `critical`, or any values set via the `--alertmanager_custom_severity_levels` option.
+* `severity`: Must be one of `warning` or `critical`, or any values set via the `--alertmanager_custom_severity_levels`
+  option.
 * `alertname` mapped to `display_name`.
 
 Required annotations:
@@ -162,9 +170,9 @@ Infered fields:
 
 * `generatorURL`: mapped to `action_url`
 
-### Plugin Output 
+### Plugin Output
 
-By default Signalilo will use the `message` Annotation to set the `plugin_output` in the Icinga Service.
+By default, Signalilo will use the `message` Annotation to set the `plugin_output` in the Icinga Service.
 
 This can be changed by using the `--alertmanager_pluginoutput_annotations` to select either a
 different Annotation or to provide a list of Annotations where the first one with a value will be used.
@@ -176,7 +184,8 @@ Annotation name when looking up the Annotation to use for the Plugin Output (for
 This allows you to configure multiple Annotations with different values that are then used
 with the corresponding Service State to set the Plugin Output.
 
-If an Annotation is not found for that specific Service State then Signalilo will fall back ot just using the Annotation name as configured.
+If an Annotation is not found for that specific Service State then Signalilo will fall back ot just using the Annotation
+name as configured.
 
 ## Integration with Icinga
 
@@ -184,7 +193,7 @@ If an Annotation is not found for that specific Service State then Signalilo wil
 
 You need to create an Icinga service host which Signalilo can use.
 Signalilo is designed to expect that it has full control over one service host in Icinga.
-Therefore you should create a service host for each Signalilo instance which you're running.
+Therefore, you should create a service host for each Signalilo instance which you're running.
 
 Each service host should look as shown below.
 You can add additional configurations (such as host variables) as you like.
@@ -201,8 +210,10 @@ object Host "signalilo_cluster.example.com"  {
 ### Icinga API user
 
 We recommend that you create an API user per Icinga service host.
-This naturally ensures that you create an API user per Signalilo instance, since you should have a service host per Signalilo instance.
-In that case, you can restrict the API user's permissions to only interact with the service host belonging to the Signalilo instance as shown below.
+This naturally ensures that you create an API user per Signalilo instance, since you should have a service host per
+Signalilo instance.
+In that case, you can restrict the API user's permissions to only interact with the service host belonging to the
+Signalilo instance as shown below.
 
 ```
 object ApiUser "signalilo_cluster.example.com"  {
@@ -232,8 +243,8 @@ object ApiUser "signalilo_cluster.example.com"  {
 ```
 
 Note that you don't have to use the same name for the API user as for its associated service host.
-However, you have to make sure that you compare `host.name` to the name of the service host for which the API user should have permissions.
-
+However, you have to make sure that you compare `host.name` to the name of the service host for which the API user
+should have permissions.
 
 ### Garbage Collection
 
@@ -249,7 +260,7 @@ All state needed for doing garbage collection is stored in Icinga service variab
 
 On startup, Signalilo checks if the matching heartbeat service is available in
 Icinga, otherwise it exits with a fatal error. During operation, Signalilo
-regularly posts its state to the heartbeat service.  If no state update was
+regularly posts its state to the heartbeat service. If no state update was
 provided, Icinga automatically marks the check as UNKNOWN.
 
 You need to configure the following service in Icinga:
@@ -284,7 +295,7 @@ If the key an annotation or label starts with `icinga_` it will also be added
 as custom variable but without any prefix. Since all labels and annotations
 will be strings, a type information needs to be provided so that a conversion
 can be done accordingly. This is done by adding the type as part of the prefix
-(`icinga_<type>_`).  Current supported types are `number` and `string`.
+(`icinga_<type>_`). Current supported types are `number` and `string`.
 
 Examples:
 
@@ -306,14 +317,15 @@ and signals that the whole Prometheus stack is healthy.
 
 In order for Signalilo to treat an alert as a heartbeat, the alert must have
 a label `heartbeat`. Signalilo will try to parse the value of that label as a
-[Go duration].  
+[Go duration].
 
-If the value is parsed successfully, Signalilo will create a Icinga service
-check with active checks enabled and with the check interval set to the the
-parsed duration plus ten percent.  We add ten percent to the parsed duration
-to account for network latencies etc, which could otherwise lead to flapping
+If the value is parsed successfully, Signalilo will create an Icinga service
+check with active checks enabled and with the check interval set to the
+parsed duration plus ten percent. We add ten percent to the parsed duration
+to account for network latencies etc., which could otherwise lead to flapping
 heartbeat checks.
 
 
 [Go duration]: https://golang.org/pkg/time/#ParseDuration
+
 [webhook_format]: https://prometheus.io/docs/alerting/configuration/#webhook_config.

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Mandatory
 * `--icinga_hostname`/`SIGNALILO_ICINGA_HOSTNAME`:
   Name of the Servicehost in Icinga2.
 * `--icinga_url`/`SIGNALILO_ICINGA_URL`:
-  URL of the Icinga API. It's possible to specify one or more URLs, if the parameter is repeated.
+  URL of the Icinga API. It's possible to specify one or more URLs. Via CLI, the parameter can be repeated. If the Parameter
+  is used as ENV, the URLs will be splittet via comma e.G.: `"http://example.com:5665,http://example2.com:5665"`
   **Please keep in mind, if the URL is switched to another Icinga-URL instead of the Icinga-Config-Master, 
- it can result in cluttered Icinga-Objects**
+ it can result in cluttered Icinga-Objects. Moreover, the FIRST URL will be the Icinga-Config-Master**
 * `--icinga_username`/`SIGNALILO_ICINGA_USERNAME`:
   Authentication against Icinga2 API.
 * `--icinga_password`/`SIGNALILO_ICINGA_PASSWORD`:

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Mandatory
 * `--icinga_hostname`/`SIGNALILO_ICINGA_HOSTNAME`:
   Name of the Servicehost in Icinga2.
 * `--icinga_url`/`SIGNALILO_ICINGA_URL`:
-  URL of the Icinga API. It's possible to specify one or more URLs. Via CLI, the parameter can be repeated. 
-  If the Parameter is used as ENV, the content will be split on commas, e.g. `"http://example.com:5665,http://example2.com:5665"` will configure two masters at `http://example.com:5665` and `http://example2.com:5665`.
+  URL of the Icinga API. It's possible to specify one or more URLs. 
+  The Parameter content will be split on newline character `\n`, e.g. `"http://example.com:5665\nhttp://example2.com:5665"` will configure two masters at `http://example.com:5665` and `http://example2.com:5665`.
   Please keep in mind that the first URL will be the Icinga-Config-Master.
 * `--icinga_username`/`SIGNALILO_ICINGA_USERNAME`:
   Authentication against Icinga2 API.
@@ -90,6 +90,8 @@ Optional
   active checks are enabled (e.g. `1.1 < icinga_service_checks_interval/repeat_interval < 5`, default: 43200s).
 * `--icinga_service_max_check_attempts`/`SIGNALILO_ICINGA_SERVICE_MAX_CHECKS_ATTEMPTS`:
   The maximum number of checks which are executed before changing to a hard state.
+* `--icinga_reconnect`/`SIGNALILO_ICINGA_RECONNECT`:
+  If it's set, Signalilo to waits for a reconnect instead of switching immediately to another URL.
 * `--alertmanager_port`/`SIGNALILO_ALERTMANAGER_PORT`:
   Port on which Signalilo listens to incoming webhooks (default 8888).
 * `--alertmanager_bearer_token`/`SIGNALILO_ALERTMANAGER_BEARER_TOKEN`:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Mandatory
 * `--icinga_hostname`/`SIGNALILO_ICINGA_HOSTNAME`:
   Name of the Servicehost in Icinga2.
 * `--icinga_url`/`SIGNALILO_ICINGA_URL`:
-  URL of the Icinga API.
+  URL of the Icinga API. It's possible to specify one or more URLs, if the parameter is repeated.
+  **Please keep in mind, if the URL is switched to another Icinga-URL instead of the Icinga-Config-Master, 
+ it can result in cluttered Icinga-Objects**
 * `--icinga_username`/`SIGNALILO_ICINGA_USERNAME`:
   Authentication against Icinga2 API.
 * `--icinga_password`/`SIGNALILO_ICINGA_PASSWORD`:

--- a/config/config.go
+++ b/config/config.go
@@ -186,7 +186,7 @@ func newIcingaClient(c *SignaliloConfig, l logr.Logger) (icinga2.Client, error) 
 		if err != nil {
 			return nil, err
 		}
-		if err = client.TestIcingaApi(url); err != nil {
+		if err = client.TestIcingaApi(); err != nil {
 			// clear client if the API url wasn't reachable
 			client = nil
 			continue

--- a/config/config.go
+++ b/config/config.go
@@ -85,17 +85,6 @@ func ConfigInitialize(configuration Configuration) {
 	// Refresh local reference to logger after setup
 	l = configuration.GetLogger()
 
-	var tmp []string
-
-	for _, ur := range config.IcingaConfig.URL {
-		st := strings.Split(ur, ",")
-		for _, b := range st {
-			tmp = append(tmp, b)
-		}
-	}
-
-	config.IcingaConfig.URL = tmp
-
 	icinga, err := newIcingaClient(config, l)
 	if err != nil {
 		l.Errorf("Unable to create new icinga client: %s", err)
@@ -249,10 +238,6 @@ func (c *MockConfiguration) SetLogger(logger logr.Logger) {
 }
 func (c *MockConfiguration) SetIcingaClient(icinga icinga2.Client) {
 	c.icingaClient = icinga
-}
-
-func (c *MockConfiguration) TestIcingaApi() error {
-	return nil
 }
 
 func NewMockConfiguration(verbosity int) Configuration {

--- a/config/config.go
+++ b/config/config.go
@@ -173,6 +173,17 @@ func newIcingaClient(c *SignaliloConfig, l logr.Logger) (icinga2.Client, error) 
 
 	var client *icinga2.WebClient
 
+	var tmp []string
+
+	for _, ur := range c.IcingaConfig.URL {
+		st := strings.Split(ur, ",")
+		for _, b := range st {
+			tmp = append(tmp, b)
+		}
+	}
+
+	c.IcingaConfig.URL = tmp
+
 	for _, url := range c.IcingaConfig.URL {
 		client, err = icinga2.New(icinga2.WebClient{
 			URL:               url,
@@ -210,9 +221,10 @@ func MockLogger(verbosity int) logr.Logger {
 }
 
 type MockConfiguration struct {
-	config       SignaliloConfig
-	logger       logr.Logger
-	icingaClient icinga2.Client
+	config          SignaliloConfig
+	logger          logr.Logger
+	icingaClient    icinga2.Client
+	icingaWebclient icinga2.WebClient
 }
 
 func (c *MockConfiguration) GetConfig() *SignaliloConfig {
@@ -232,6 +244,18 @@ func (c *MockConfiguration) SetLogger(logger logr.Logger) {
 }
 func (c *MockConfiguration) SetIcingaClient(icinga icinga2.Client) {
 	c.icingaClient = icinga
+}
+
+func (c *MockConfiguration) SetIcigaUrl(url string) {
+	c.icingaWebclient.URL = url
+}
+
+func (c *MockConfiguration) GetClientConfig() icinga2.WebClient {
+	return c.icingaWebclient.GetClientConfig()
+}
+
+func (c *MockConfiguration) TestIcingaApi() error {
+	return nil
 }
 
 func NewMockConfiguration(verbosity int) Configuration {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,6 @@ require (
 	github.com/prometheus/alertmanager v0.24.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.7.4
-	github.com/vshn/go-icinga2-client v0.0.15
+	github.com/vshn/go-icinga2-client v0.0.16
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/vshn/go-icinga2-client v0.0.15 h1:YgLjDCPJl0d7CNlxDcnpwDXoE6K30CBDKaAZ1KTsm2E=
-github.com/vshn/go-icinga2-client v0.0.15/go.mod h1:zT3rZf1cP0uTiXfwyhMCt+WA4woFG1XvMPwDRNVKbcM=
+github.com/vshn/go-icinga2-client v0.0.16 h1:+Bn0+HnJXMS1kFdpG+30LcoroFL7jQA16z9Cp+aSbWk=
+github.com/vshn/go-icinga2-client v0.0.16/go.mod h1:zT3rZf1cP0uTiXfwyhMCt+WA4woFG1XvMPwDRNVKbcM=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=

--- a/serve.go
+++ b/serve.go
@@ -110,8 +110,11 @@ func (s *ServeCommand) startHeartbeat() error {
 				// In some rare cases there could be an Icinga2 reload for a config update and the API is not reachable.
 				// So, the switch off of the Config-Master would take in place, but we don't want an unnecessary switch
 				// to the secondary Icinga2 instance.
-				s.logger.Infof("Waiting %s for reconnect", s.config.Reconnect)
-				time.Sleep(s.config.Reconnect)
+				if s.config.Reconnect > 0 {
+					s.logger.Infof("Waiting %s for reconnect", s.config.Reconnect)
+					time.Sleep(s.config.Reconnect)
+				}
+
 				erro := s.icingaClient.TestIcingaApi(s.icingaClient.GetClientConfig().URL)
 
 				if erro != nil {
@@ -222,7 +225,7 @@ func configureServeCommand(app *kingpin.Application) {
 	serve.Flag("icinga_service_checks_interval", "Interval (in seconds) to be used for icinga check_interval and retry_interval").Envar("SIGNALILO_ICINGA_SERVICE_CHECKS_INTERVAL").Default("12h").DurationVar(&s.config.ChecksInterval)
 	serve.Flag("icinga_service_max_check_attempts", "The maximum number of checks which are executed before changing to a hard state").Envar("SIGNALILO_ICINGA_SERVICE_MAX_CHECK_ATTEMPTS").Default("1").IntVar(&s.config.MaxCheckAttempts)
 	serve.Flag("icinga_static_service_var", "A variable to be set on each Icinga service created by Signalilo. The expected format is variable=value. Can be repeated.").Envar("SIGNALILO_ICINGA_STATIC_SERVICE_VAR").StringMapVar(&s.config.StaticServiceVars)
-	serve.Flag("icinga_reconnect", "Interval to be used for Signalilo to wait for a reconnect instead of switching immediately to another URL").Envar("SIGNALILO_ICINGA_RECONNECT").Default("10s").DurationVar(&s.config.Reconnect)
+	serve.Flag("icinga_reconnect", "If it's set, Signalilo to waits for a reconnect instead of switching immediately to another URL.").Envar("SIGNALILO_ICINGA_RECONNECT").Default("0").DurationVar(&s.config.Reconnect)
 
 	// Alert manager configuration
 	serve.Flag("alertmanager_port", "Listening port for the Alertmanager webhook").Default("8888").Envar("SIGNALILO_ALERTMANAGER_PORT").IntVar(&s.port)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->
This PR fixes '[Feature Request] Support for Redundant Master API's' #57 

It' now possible to specify one or more Icinga-URLs. If one URL is not reachable, it'll switch to the URL which doesn't response with an error.
## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the README.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
